### PR TITLE
自動更新

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,42 +1,23 @@
 $(function(){
-  function buildMessage(message){
-    if (message.image) {
-      var html = 
-      `<div class="chat-post">
+  function buildHTML(message) {
+     var image = message.image? `<img src=  ${message.image}  class="lower-message__image">` : "";
+       html = 
+      `<div class="chat-post" data-message-id= ${message.id}> 
         <div class="chat-name">
           ${message.user_name}
           <span class="message-date">
-           ${message.created_at}
+              ${message.created_at}
           </span>
         </div>
         <div class="chat-message">
           <p class="message__content">
             ${message.content}
           </p>
-          <img class="lower-message__image" src=${message.image}>
+          ${image}
         </div>
       </div>`
-      return html;
-    } else {
-      var html =
-      `<div class="chat-post">
-        <div class="chat-name">
-          ${message.user_name}
-          <span class="message-date">
-            ${message.created_at}
-          </span>
-        </div>
-        <div class="chat-message">
-          <p class="message__content">
-            ${message.content}
-          </p>
-        </div>
-      </div>`
-      return html;
-    };
-  }
-
-
+    return html;
+  };
 
   $('#new_message').on('submit', function(e){
     e.preventDefault()
@@ -51,7 +32,7 @@ $(function(){
       contentType: false
     })
     .done(function(data){
-      var html = buildMessage(data);
+      var html = buildHTML(data);
       $('.chat-main__message-list').append(html);
       $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
       $('#new_message')[0].reset();
@@ -61,4 +42,42 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     });
   })
+
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    var last_message_id = $('.chat-post:last').data("message-id");
+ 
+    $.ajax({
+      //ルーティングで設定した通りのURLを指定
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          
+          insertHTML += buildHTML(message)
+        });
+        
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.chat-main__message-list').append(insertHTML);
+       
+        $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+      }
+    })
+    .fail(function(){
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -44,32 +44,23 @@ $(function(){
   })
 
   var reloadMessages = function() {
-    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
     var last_message_id = $('.chat-post:last').data("message-id");
  
     $.ajax({
-      //ルーティングで設定した通りのURLを指定
       url: "api/messages",
-      //ルーティングで設定した通りhttpメソッドをgetに指定
       type: 'get',
       dataType: 'json',
-      //dataオプションでリクエストに値を含める
       data: {id: last_message_id}
     })
     
     .done(function(messages) {
       if (messages.length !== 0) {
-        //追加するHTMLの入れ物を作る
         var insertHTML = '';
-        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
         $.each(messages, function(i, message) {
           
           insertHTML += buildHTML(message)
         });
-        
-        //メッセージが入ったHTMLに、入れ物ごと追加
-        $('.chat-main__message-list').append(insertHTML);
-       
+        $('.chat-main__message-list').append(insertHTML);      
         $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
       }
     })

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -75,6 +75,7 @@ $word-color__one: #ffffff;
         .message-date {
           color: #999999;
           font-size: 12px;
+          margin-left: 5px;
         }
       }
       .chat-message {

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,10 +1,7 @@
 class Api::MessagesController < ApplicationController
   def index
-    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
     group = Group.find(params[:group_id])
-    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
     last_message_id = params[:id].to_i
-    # 取得したグループでのメッセージ達から、idがlast_message_idよりも新しい(大きい)メッセージ達のみを取得
     @messages = group.messages.includes(:user).where("id > ?", last_message_id)
   end
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,7 +1,7 @@
-.chat-post
-  .chat-name 
+.chat-post{data:{message: {id: message.id}}}
+  .chat-name
     = message.user.name
-    %span.message-date 
+    %span.message-date<>
       = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
   .chat-message
     - if message.content.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,6 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+#idもデータとして渡す
+json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,5 +2,4 @@ json.content    @message.content
 json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.user_name @message.user.name
-#idもデータとして渡す
 json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-  end
 
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
+  end
 end


### PR DESCRIPTION
# What
chatspaceの自動更新機能の実装

- メッセージを表示する際カスタムデータ属性は追加
- APIとして機能するコントローラーの作成とデータ返すアクションのコーディング
- namespaceを使ったコントローラファイルのルーティング
- index.json.jbuilderを作成し、json形式でレスポンス可能にする実装
- reloadMessagesという名前で関数を作成し、作成したアクションを動かすリクエストを実装
- buildHTMLメソッドの編集
- 一定時間が経過するごとに処理を実行するsetInterval()関数の実装
- animate関数を使い自動スクロールの実装
- matchメソッドと正規表現を使い、自動更新のページを指定

# Why
この機能でいちいち新規のメッセージを見るためリロードしなくていいようになり、ユーザーの利便性向上が図れる